### PR TITLE
Add as const satisfies to insight constants and remove formatGeneratedAt

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/insight_constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/insight_constants.ts
@@ -23,27 +23,3 @@ export const impactLabels = {
   medium: i18n.translate('xpack.streams.insights.impact.medium', { defaultMessage: 'Medium' }),
   low: i18n.translate('xpack.streams.insights.impact.low', { defaultMessage: 'Low' }),
 } as const satisfies Record<InsightImpactLevel, string>;
-
-export const formatGeneratedAt = (dateStr: string): string => {
-  const diffMins = Math.floor((Date.now() - new Date(dateStr).getTime()) / 60000);
-  if (diffMins < 1) {
-    return i18n.translate('xpack.streams.insights.justNow', { defaultMessage: 'just now' });
-  }
-  if (diffMins < 60) {
-    return i18n.translate('xpack.streams.insights.minutesAgo', {
-      defaultMessage: '{count} {count, plural, one {minute} other {minutes}} ago',
-      values: { count: diffMins },
-    });
-  }
-  const diffHours = Math.floor(diffMins / 60);
-  if (diffHours < 24) {
-    return i18n.translate('xpack.streams.insights.hoursAgo', {
-      defaultMessage: '{count} {count, plural, one {hour} other {hours}} ago',
-      values: { count: diffHours },
-    });
-  }
-  return i18n.translate('xpack.streams.insights.daysAgo', {
-    defaultMessage: '{count} {count, plural, one {day} other {days}} ago',
-    values: { count: Math.floor(diffHours / 24) },
-  });
-};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/insight_constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/insight_constants.ts
@@ -8,21 +8,42 @@
 import { i18n } from '@kbn/i18n';
 import type { InsightImpactLevel } from '@kbn/streams-schema';
 
-export const impactBadgeColors: Record<
-  InsightImpactLevel,
-  'danger' | 'warning' | 'primary' | 'hollow'
-> = {
+export const impactBadgeColors = {
   critical: 'danger',
   high: 'warning',
   medium: 'primary',
   low: 'hollow',
-};
+} as const satisfies Record<InsightImpactLevel, string>;
 
-export const impactLabels: Record<InsightImpactLevel, string> = {
+export const impactLabels = {
   critical: i18n.translate('xpack.streams.insights.impact.critical', {
     defaultMessage: 'Critical',
   }),
   high: i18n.translate('xpack.streams.insights.impact.high', { defaultMessage: 'High' }),
   medium: i18n.translate('xpack.streams.insights.impact.medium', { defaultMessage: 'Medium' }),
   low: i18n.translate('xpack.streams.insights.impact.low', { defaultMessage: 'Low' }),
+} as const satisfies Record<InsightImpactLevel, string>;
+
+export const formatGeneratedAt = (dateStr: string): string => {
+  const diffMins = Math.floor((Date.now() - new Date(dateStr).getTime()) / 60000);
+  if (diffMins < 1) {
+    return i18n.translate('xpack.streams.insights.justNow', { defaultMessage: 'just now' });
+  }
+  if (diffMins < 60) {
+    return i18n.translate('xpack.streams.insights.minutesAgo', {
+      defaultMessage: '{count} {count, plural, one {minute} other {minutes}} ago',
+      values: { count: diffMins },
+    });
+  }
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) {
+    return i18n.translate('xpack.streams.insights.hoursAgo', {
+      defaultMessage: '{count} {count, plural, one {hour} other {hours}} ago',
+      values: { count: diffHours },
+    });
+  }
+  return i18n.translate('xpack.streams.insights.daysAgo', {
+    defaultMessage: '{count} {count, plural, one {day} other {days}} ago',
+    values: { count: Math.floor(diffHours / 24) },
+  });
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import moment from 'moment';
 import { TaskStatus } from '@kbn/streams-schema';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
@@ -31,7 +32,7 @@ import { useKibana } from '../../../../hooks/use_kibana';
 import { useTaskPolling } from '../../../../hooks/use_task_polling';
 import { getFormattedError } from '../../../../util/errors';
 import { FeedbackButtons } from './feedback_buttons';
-import { formatGeneratedAt, impactBadgeColors, impactLabels } from './insight_constants';
+import { impactBadgeColors, impactLabels } from './insight_constants';
 import { InsightFlyout } from './insight_flyout';
 
 export function Summary({ count }: { count: number }) {
@@ -213,7 +214,7 @@ export function Summary({ count }: { count: number }) {
         width: '150px',
         render: (generatedAt: string) => (
           <EuiText size="s" color="subdued">
-            {formatGeneratedAt(generatedAt)}
+            {moment(generatedAt).fromNow()}
           </EuiText>
         ),
       },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
@@ -21,7 +21,6 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import moment from 'moment';
 import { TaskStatus } from '@kbn/streams-schema';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
@@ -32,32 +31,8 @@ import { useKibana } from '../../../../hooks/use_kibana';
 import { useTaskPolling } from '../../../../hooks/use_task_polling';
 import { getFormattedError } from '../../../../util/errors';
 import { FeedbackButtons } from './feedback_buttons';
-import { impactBadgeColors, impactLabels } from './insight_constants';
+import { formatGeneratedAt, impactBadgeColors, impactLabels } from './insight_constants';
 import { InsightFlyout } from './insight_flyout';
-
-const formatGeneratedAt = (dateStr: string): string => {
-  const diffMins = Math.floor((Date.now() - new Date(dateStr).getTime()) / 60000);
-  if (diffMins < 1) {
-    return i18n.translate('xpack.streams.insights.justNow', { defaultMessage: 'just now' });
-  }
-  if (diffMins < 60) {
-    return i18n.translate('xpack.streams.insights.minutesAgo', {
-      defaultMessage: '{count} {count, plural, one {minute} other {minutes}} ago',
-      values: { count: diffMins },
-    });
-  }
-  const diffHours = Math.floor(diffMins / 60);
-  if (diffHours < 24) {
-    return i18n.translate('xpack.streams.insights.hoursAgo', {
-      defaultMessage: '{count} {count, plural, one {hour} other {hours}} ago',
-      values: { count: diffHours },
-    });
-  }
-  return i18n.translate('xpack.streams.insights.daysAgo', {
-    defaultMessage: '{count} {count, plural, one {day} other {days}} ago',
-    values: { count: Math.floor(diffHours / 24) },
-  });
-};
 
 export function Summary({ count }: { count: number }) {
   const {
@@ -238,7 +213,7 @@ export function Summary({ count }: { count: number }) {
         width: '150px',
         render: (generatedAt: string) => (
           <EuiText size="s" color="subdued">
-            {moment(generatedAt).fromNow()}
+            {formatGeneratedAt(generatedAt)}
           </EuiText>
         ),
       },


### PR DESCRIPTION
## Summary
- Move `formatGeneratedAt` function from `summary.tsx` to `insight_constants.ts` to colocate with other insight constants
- Add `as const satisfies` to `impactBadgeColors` and `impactLabels` for better type narrowing
- Use `formatGeneratedAt` in the table render column instead of `moment().fromNow()`, restoring i18n-aware relative time formatting
- Remove unused `moment` import from `summary.tsx`

Refs: https://github.com/elastic/kibana/pull/259457#issuecomment-4141681544